### PR TITLE
Name and tag predicate fix

### DIFF
--- a/docs/DeveloperGuide.adoc
+++ b/docs/DeveloperGuide.adoc
@@ -234,7 +234,7 @@ public NameAndTagsContainsKeywordsPredicate(List<String> nameKeywords, List<Stri
 
 The method `test(ReadOnlyPerson person)` iterates through `nameKeywords` and `tagKeywords` to find a match of every `person` from the address book.
 
-Below is an extract of the method `test(ReadOnlyPerson person`. The tags of each person are retrieved by the `getTags()` method. This method iterates through `tagKeywords` and counts the number of matches against `tagsOfPerson`. If the count is equal to the size of `tagKeywords`, this means all the keywords in `tagKeywords` matches. The `tagFound` will then be set to `true`.
+Below is an extract of the method `test(ReadOnlyPerson person)`. The tags of each person are retrieved by the `getTags()` method. This method iterates through `tagKeywords` and counts the number of matches against `tagsOfPerson`. If the count is equal to the size of `tagKeywords`, this means all the keywords in `tagKeywords` matches. The `tagFound` will then be set to `true`.
 
 [source,java]
 ----
@@ -242,20 +242,12 @@ boolean tagFound = false;
 
 int numTagKeywords = tagKeywords.size();
 int tagsMatchedCount = 0;
-
 if (!tagKeywords.isEmpty()) {
-    Set<Tag> tagsOfPerson = person.getTags();
-    for (Tag personTag : tagsOfPerson) {
-        for (String findTag : tagKeywords) {
-            if (personTag.tagName.equalsIgnoreCase(findTag)) {
-                tagsMatchedCount++;
-            }
-        }
-    }
+    tagsMatchedCount = countTagMatches(person);
+}
 
-    if (tagsMatchedCount == numTagKeywords) {
-        tagFound = true;
-    }
+if (tagsMatchedCount == numTagKeywords) {
+    tagFound = true;
 }
 ----
 

--- a/src/main/java/seedu/address/model/person/NameAndTagsContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/NameAndTagsContainsKeywordsPredicate.java
@@ -25,16 +25,8 @@ public class NameAndTagsContainsKeywordsPredicate implements Predicate<ReadOnlyP
 
         int numTagKeywords = tagKeywords.size();
         int tagsMatchedCount = 0;
-
         if (!tagKeywords.isEmpty()) {
-            Set<Tag> tagsOfPerson = person.getTags();
-            for (Tag personTag : tagsOfPerson) {
-                for (String findTag : tagKeywords) {
-                    if (personTag.tagName.equalsIgnoreCase(findTag)) {
-                        tagsMatchedCount++;
-                    }
-                }
-            }
+            tagsMatchedCount = countTagMatches(person);
         }
 
         if (tagsMatchedCount == numTagKeywords) {
@@ -56,6 +48,20 @@ public class NameAndTagsContainsKeywordsPredicate implements Predicate<ReadOnlyP
         }
 
         return nameFound && tagFound;
+    }
+
+    public int countTagMatches(ReadOnlyPerson person) {
+        int tagsMatchedCount = 0;
+
+        Set<Tag> tagsOfPerson = person.getTags();
+        for (Tag personTag : tagsOfPerson) {
+            for (String findTag : tagKeywords) {
+                if (personTag.tagName.equalsIgnoreCase(findTag)) {
+                    tagsMatchedCount++;
+                }
+            }
+        }
+        return tagsMatchedCount;
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/NameAndTagsContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/NameAndTagsContainsKeywordsPredicate.java
@@ -50,6 +50,9 @@ public class NameAndTagsContainsKeywordsPredicate implements Predicate<ReadOnlyP
         return nameFound && tagFound;
     }
 
+    /**
+     * Counts the number of matching tags from person and returns the count
+     */
     public int countTagMatches(ReadOnlyPerson person) {
         int tagsMatchedCount = 0;
 

--- a/src/main/java/seedu/address/model/person/NameAndTagsContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/NameAndTagsContainsKeywordsPredicate.java
@@ -51,20 +51,30 @@ public class NameAndTagsContainsKeywordsPredicate implements Predicate<ReadOnlyP
     }
 
     /**
-     * Counts the number of matching tags from person and returns the count
+     * Counts the number of matching tags of a person person and returns the count
      */
     public int countTagMatches(ReadOnlyPerson person) {
         int tagsMatchedCount = 0;
 
         Set<Tag> tagsOfPerson = person.getTags();
         for (Tag personTag : tagsOfPerson) {
-            for (String findTag : tagKeywords) {
-                if (personTag.tagName.equalsIgnoreCase(findTag)) {
-                    tagsMatchedCount++;
-                }
+            if (hasTag(personTag)) {
+                tagsMatchedCount++;
             }
         }
         return tagsMatchedCount;
+    }
+
+    /**
+     * Returns true if the tag can be found in the tag keywords. Otherwise returns false.
+     */
+    public boolean hasTag(Tag tag) {
+        for (String findTag : tagKeywords) {
+            if (tag.tagName.equalsIgnoreCase(findTag)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     @Override


### PR DESCRIPTION
I created another method "countTagMatches" to count the number of tag matches to make the code in the "test" method shorter. But I still can't think of a way to fix the "arrowhead code" for the double for-loop in the new method.